### PR TITLE
Add cacheable auto-rotation of keypairs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timecop (0.9.2)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -145,6 +146,7 @@ DEPENDENCIES
   rubocop-rails
   shoulda-matchers
   sqlite3
+  timecop
 
 BUNDLED WITH
    2.1.4

--- a/db/migrate/20201116144600_add_validity_to_keypairs.rb
+++ b/db/migrate/20201116144600_add_validity_to_keypairs.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AddValidityToKeypairs < ActiveRecord::Migration[6.0]
+  class Keypair < ActiveRecord::Base; end
+
+  def change # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    change_table :keypairs, bulk: true do |t|
+      t.datetime :not_before, precision: 6
+      t.datetime :not_after, precision: 6
+      t.datetime :expires_at, precision: 6
+    end
+
+    reversible do |dir|
+      dir.up do
+        Keypair.find_each do |keypair|
+          keypair.update!(
+            not_before: keypair.created_at,
+            not_after: keypair.created_at + 1.month,
+            expires_at: keypair.created_at + 2.months
+          )
+        end
+      end
+    end
+
+    change_column_null :keypairs, :not_before, false
+    change_column_null :keypairs, :not_after, false
+    change_column_null :keypairs, :expires_at, false
+  end
+end

--- a/keypairs.gemspec
+++ b/keypairs.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rails'                  # Linter for Rails-specific analysis
   spec.add_development_dependency 'shoulda-matchers'               # RSpec matchers
   spec.add_development_dependency 'sqlite3'                        # Database adapter
+  spec.add_development_dependency 'timecop'                        # Freeze time to test time-dependent code
 end

--- a/lib/keypair.rb
+++ b/lib/keypair.rb
@@ -53,12 +53,11 @@ class Keypair < ActiveRecord::Base
   # @!method valid
   #   @!scope class
   #   Non-expired keypairs are considered valid and can be used to validate signatures and export public jwks.
-  #   It uses a subquery to make sure a +find_by+ actually searches only the non-expired ones.
-  scope :valid, -> { where(id: unscoped.where('? < expires_at', Time.zone.now)) }
+  scope :valid, -> { where(arel_table[:expires_at].gt(Time.zone.now)) }
 
   # @return [Keypair] the keypair used to sign messages and autorotates if it has expired.
   def self.current
-    order(not_before: :asc).where('not_before <= ? AND ? <= not_after', Time.zone.now, Time.zone.now).last || create!
+    order(not_before: :asc).where(arel_table[:not_before].lteq(Time.zone.now)).where(arel_table[:not_after].gteq(Time.zone.now)).last || create!
   end
 
   # The JWK Set of our valid keypairs.

--- a/lib/keypairs.rb
+++ b/lib/keypairs.rb
@@ -4,6 +4,7 @@ require 'lockbox'
 
 autoload :Keypair, 'keypair.rb'
 
+# The Keypairs module contains common functionality in support of the {Keypair} model.
 module Keypairs
   autoload :PublicKeysController, 'keypairs/public_keys_controller'
 end

--- a/lib/keypairs/public_keys_controller.rb
+++ b/lib/keypairs/public_keys_controller.rb
@@ -18,7 +18,9 @@ module Keypairs
   #  }
   class PublicKeysController < ActionController::API
     def index
-      render json: Keypair.keyset
+      # Always cache for 1 week, our rotation interval is much more than a week
+      expires_in 1.week, public: true
+      render json: Keypair.cached_keyset
     end
   end
 end

--- a/spec/controllers/keypairs/public_keys_controller_spec.rb
+++ b/spec/controllers/keypairs/public_keys_controller_spec.rb
@@ -2,16 +2,17 @@
 
 RSpec.describe Keypairs::PublicKeysController, type: :request do
   context 'GET #index' do
-    let!(:keypair1) { Keypair.create(created_at: 4.days.ago) }
-    let!(:keypair2) { Keypair.create(created_at: 3.days.ago) }
-    let!(:keypair3) { Keypair.create(created_at: 2.days.ago) }
-    let!(:keypair4) { Keypair.create(created_at: 1.day.ago) }
+    let!(:keypair1) { Keypair.create(created_at: 14.weeks.ago) }
+    let!(:keypair2) { Keypair.create(created_at: 10.weeks.ago) }
+    let!(:keypair3) { Keypair.create(created_at: 6.weeks.ago) }
+    let!(:keypair4) { Keypair.create(created_at: 2.weeks.ago) }
+    let(:created_keypair) { Keypair.unscoped.last }
 
     before { get '/jwks' }
 
-    it 'renders the public exports of valid keys (the last three)' do
+    it 'renders the public exports of valid keys' do
       expect(response.body).to eq({
-        keys: [keypair4, keypair3, keypair2].map(&:public_jwk_export)
+        keys: [keypair3, keypair4, created_keypair].map(&:public_jwk_export)
       }.to_json)
     end
 
@@ -25,9 +26,8 @@ RSpec.describe Keypairs::PublicKeysController, type: :request do
     #
     # NOTE: Be carefull with enabeling this, since if we rotate a key, it's not valid immediately!
     #
-    # it 'sets the expiry headers' do
-    #   get :index, format: :json
-    #   expect(response.headers['Cache-Control']).to eq("max-age=#{1.week.to_i}, public")
-    # end
+    it 'sets the expiry headers' do
+      expect(response.headers['Cache-Control']).to eq("max-age=#{1.week.to_i}, public")
+    end
   end
 end

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -110,10 +110,9 @@ RSpec.describe Keypair, type: :model do
 
   describe 'scopes', timecop: :freeze do
     describe '.valid' do
-      it 'returns the last three keys' do
-        subquery = described_class.unscoped.where('? < expires_at', Time.zone.now)
-        last_three = described_class.where(id: subquery)
-        expect(described_class.valid.to_sql).to eq(last_three.to_sql)
+      it 'returns the non-expired keys' do
+        non_expired = described_class.unscoped.where(described_class.arel_table[:expires_at].gt(Time.zone.now))
+        expect(described_class.valid.to_sql).to eq(non_expired.to_sql)
       end
       it 'works with find_by' do
         keypairs = Array.new(4) { |i| described_class.create! not_before: i.months.ago }
@@ -121,9 +120,8 @@ RSpec.describe Keypair, type: :model do
         expect(described_class.valid.where(id: invalid.id)).to be_empty
       end
       it 'works with order' do
-        subquery = described_class.unscoped.where('? < expires_at', Time.zone.now)
-        last_three = described_class.where(id: subquery).order(:id)
-        expect(described_class.order(:id).valid.to_sql).to eq(last_three.to_sql)
+        non_expired = described_class.unscoped.where(described_class.arel_table[:expires_at].gt(Time.zone.now)).order(:id)
+        expect(described_class.order(:id).valid.to_sql).to eq(non_expired.to_sql)
       end
     end
   end

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Keypair, type: :model do
     it { is_expected.to have_db_column(:id).of_type(:integer).with_options(null: false) }
     it { is_expected.to have_db_column(:jwk_kid).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_column(:_keypair_ciphertext).of_type(:text).with_options(null: false) }
+    it { is_expected.to have_db_column(:not_before).of_type(:datetime).with_options(null: true, precision: 6) }
+    it { is_expected.to have_db_column(:expires_at).of_type(:datetime).with_options(null: true, precision: 6) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false, precision: 6) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false, precision: 6) }
     it { is_expected.to have_db_index(:created_at) }
@@ -13,6 +15,7 @@ RSpec.describe Keypair, type: :model do
 
   describe 'settings' do
     it { expect(described_class::ALGORITHM).to eq 'RS256' }
+    it { expect(described_class::ROTATION_INTERVAL).to eq 1.month }
     it { is_expected.to be_a(ActiveRecord::Base) }
     it { is_expected.to encrypt_attribute(:_keypair) }
   end
@@ -20,6 +23,20 @@ RSpec.describe Keypair, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:_keypair) }
     it { is_expected.to validate_presence_of(:jwk_kid) }
+    it { is_expected.to validate_presence_of(:not_before) }
+    it { is_expected.to validate_presence_of(:expires_at) }
+
+    it 'should not allow not_before to be after not_after' do
+      subject = described_class.new(not_before: 10.days.from_now, not_after: 5.days.from_now)
+      expect(subject).to_not be_valid
+      expect(subject.errors.to_hash).to eq(not_after: ['must be after not before'])
+    end
+
+    it 'should not allow not_after to be after expires_at' do
+      subject = described_class.new(not_after: 10.days.from_now, expires_at: 5.days.from_now)
+      expect(subject).to_not be_valid
+      expect(subject.errors.to_hash).to eq(expires_at: ['must be after not after'])
+    end
   end
 
   describe 'callbacks' do
@@ -56,22 +73,55 @@ RSpec.describe Keypair, type: :model do
         expect { subject.reload }.not_to change { subject.jwk_kid }
       end
     end
+
+    describe '#set_validity', timecop: :freeze do
+      it { expect(subject.not_before).to eq Time.zone.now.floor(6) }
+      it { expect(subject.not_after).to eq 1.month.from_now.floor(6) }
+      it { expect(subject.expires_at).to eq 2.months.from_now.floor(6) }
+
+      it 'does not change not_before after persisting' do
+        expect { subject.save! }.not_to change { subject.not_before }
+      end
+
+      it 'does not change not_after after persisting' do
+        expect { subject.save! }.not_to change { subject.not_after }
+      end
+
+      it 'does not change expires_at after persisting' do
+        expect { subject.save! }.not_to change { subject.expires_at }
+      end
+
+      it 'does not change not_before after reloading' do
+        subject.save
+        expect { subject.reload }.not_to change { subject.not_before }
+      end
+
+      it 'does not change not_after after reloading' do
+        subject.save
+        expect { subject.reload }.not_to change { subject.not_after }
+      end
+
+      it 'does not change expires_at after reloading' do
+        subject.save
+        expect { subject.reload }.not_to change { subject.expires_at }
+      end
+    end
   end
 
-  describe 'scopes' do
+  describe 'scopes', timecop: :freeze do
     describe '.valid' do
       it 'returns the last three keys' do
-        subquery = described_class.unscoped.order(created_at: :desc).limit(3)
+        subquery = described_class.unscoped.where('? < expires_at', Time.zone.now)
         last_three = described_class.where(id: subquery)
         expect(described_class.valid.to_sql).to eq(last_three.to_sql)
       end
       it 'works with find_by' do
-        keypairs = Array.new(4) { described_class.create! }
-        invalid = keypairs.min_by(&:created_at)
+        keypairs = Array.new(4) { |i| described_class.create! not_before: i.months.ago }
+        invalid = keypairs.min_by(&:expires_at)
         expect(described_class.valid.where(id: invalid.id)).to be_empty
       end
       it 'works with order' do
-        subquery = described_class.unscoped.order(created_at: :desc).limit(3)
+        subquery = described_class.unscoped.where('? < expires_at', Time.zone.now)
         last_three = described_class.where(id: subquery).order(:id)
         expect(described_class.order(:id).valid.to_sql).to eq(last_three.to_sql)
       end
@@ -93,7 +143,7 @@ RSpec.describe Keypair, type: :model do
         let!(:keypair1) { described_class.create!(created_at: 2.weeks.ago) }
         let!(:keypair2) { described_class.create!(created_at: 6.weeks.ago) }
         let!(:keypair3) { described_class.create!(created_at: 10.weeks.ago) }
-        it 'returns the latest' do
+        it 'returns the currently valid one' do
           expect(described_class.current).to eq keypair1
         end
       end
@@ -113,27 +163,87 @@ RSpec.describe Keypair, type: :model do
     describe '.keyset' do
       subject { described_class.keyset }
 
-      context 'with keypairs' do
-        let!(:keypair1) { described_class.create(created_at: 8.minutes.ago) }
-        let!(:keypair2) { described_class.create(created_at: 7.minutes.ago) }
-        let!(:keypair3) { described_class.create(created_at: 11.minutes.ago) }
-        let!(:keypair4) { described_class.create(created_at: 10.minutes.ago) }
+      context 'with past and present keypairs' do
+        let!(:keypair1) { described_class.create(created_at: 15.weeks.ago) }
+        let!(:keypair2) { described_class.create(created_at: 11.weeks.ago) }
+        let!(:keypair3) { described_class.create(created_at: 7.weeks.ago) }
+        let!(:keypair4) { described_class.create(created_at: 3.weeks.ago) }
+        let(:created_keypair) { described_class.unscoped.last }
 
         let(:expected) do
           [
-            keypair2.public_jwk_export,
-            keypair1.public_jwk_export,
-            keypair4.public_jwk_export
+            keypair3.public_jwk_export,
+            keypair4.public_jwk_export,
+            created_keypair.public_jwk_export
           ]
         end
 
-        it 'contains the public_jwk_export of only the last three keypairs' do
+        it 'creates a new future keypair' do
+          expect { described_class.keyset }.to change { described_class.count }.by(1)
+        end
+
+        it 'creates the new keypair for the correct time', timecop: :freeze do
+          described_class.keyset
+          expect(created_keypair.not_before).to eq (3.weeks.ago + 1.month).floor(6)
+          expect(created_keypair.not_after).to eq (3.weeks.ago + 2.months).floor(6)
+          expect(created_keypair.expires_at).to eq (3.weeks.ago + 3.months).floor(6)
+        end
+
+        it 'contains the public_jwk_export of only the valid keypairs' do
+          expect(subject[:keys]).to eq(expected)
+        end
+      end
+
+      context 'with past, present and future keypairs' do
+        let!(:keypair1) { described_class.create(created_at: 15.weeks.ago) }
+        let!(:keypair2) { described_class.create(created_at: 11.weeks.ago) }
+        let!(:keypair3) { described_class.create(created_at: 7.weeks.ago) }
+        let!(:keypair4) { described_class.create(created_at: 3.weeks.ago) }
+        let!(:keypair5) { described_class.create(not_before: 1.week.from_now) }
+
+        let(:expected) do
+          [
+            keypair3.public_jwk_export,
+            keypair4.public_jwk_export,
+            keypair5.public_jwk_export
+          ]
+        end
+
+        it 'does not create a new future keypair' do
+          expect { described_class.keyset }.to_not change { described_class.count }
+        end
+
+        it 'contains the public_jwk_export of only the valid keypairs' do
           expect(subject[:keys]).to eq(expected)
         end
       end
 
       context 'without keypairs' do
-        it { expect(subject[:keys]).to eq([]) }
+        let(:created_keypair) { described_class.unscoped.last }
+
+        it 'creates a new keypair' do
+          expect { described_class.keyset }.to change { described_class.count }.by(1)
+        end
+
+        it 'creates the new keypair for the correct time', timecop: :freeze do
+          described_class.keyset
+          expect(created_keypair.not_before).to eq Time.zone.now.floor(6)
+          expect(created_keypair.not_after).to eq 1.month.from_now.floor(6)
+          expect(created_keypair.expires_at).to eq 2.months.from_now.floor(6)
+        end
+
+        it 'contains the public_jwk_export of the newly created keypair' do
+          expect(subject[:keys]).to eq([created_keypair.public_jwk_export])
+        end
+      end
+    end
+
+    describe '.cached_keyset' do
+      it 'caches the result', timecop: :freeze do
+        test_keyset = { foo: 'bar' }
+        expect(described_class).to receive(:keyset).and_return(test_keyset)
+        expect(Rails.cache).to receive(:fetch).with('keypairs/Keypair/keyset', expires_in: 12.hours).and_call_original
+        expect(described_class.cached_keyset).to eq(test_keyset)
       end
     end
 
@@ -229,15 +339,15 @@ RSpec.describe Keypair, type: :model do
         end
       end
       context 'for id_token signed with older but valid keypair' do
-        let!(:keypairs) { Array.new(3) { described_class.create! } }
-        let!(:keypair) { keypairs.min_by(&:created_at) }
+        let!(:keypairs) { Array.new(3) { |i| described_class.create! not_before: (i - 1).months.ago } }
+        let!(:keypair) { keypairs.min_by(&:expires_at) }
         it 'retuns the payload' do
           expect(subject).to eq payload
         end
       end
       context 'for id_token signed with expired keypair' do
-        let!(:keypairs) { Array.new(5) { described_class.create! } }
-        let!(:keypair) { keypairs.min_by(&:created_at) }
+        let!(:keypairs) { Array.new(5) { |i| described_class.create! not_before: i.months.ago } }
+        let!(:keypair) { keypairs.min_by(&:expires_at) }
         it 'raises an decode error' do
           expect { subject }.to raise_error JWT::DecodeError
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'combustion'
 
 Bundler.require(*Rails.groups)
 
+Rails.application.config.cache_store = :null_store
+
 # Load the parts from rails we need with combustion
 Combustion.initialize! :active_record, :action_controller
 

--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'timecop'
+
+RSpec.configure do |config|
+  config.before(:each, :timecop) do |example|
+    case example.metadata[:timecop].to_sym
+    when :freeze then Timecop.freeze
+    else raise NotImplementedError, 'This timecop helper only supports `:freeze`'
+    end
+  end
+
+  config.after(:each, :timecop) do
+    Timecop.return
+  end
+end


### PR DESCRIPTION
Closes #1

This will add proper auto-rotation of keypairs by adding three fields:
- `not_before` which determines when we start using a keypair for signing
- `not_after` which determines when we stop using a keypair for signing
- `expires_at` which determines when a keypair can no longer be used for signature validation

Each of these is one month (rotation interval) apart, which means we'll always have three valid keypairs (one past, one current, one future). There's some caching on the keyset itself to reduce the number of SQL queries, as well as a `Cache-Control` header on the endpoint itself of 1 week, which should allow all clients to pick up the new keypair before it starts being used.