### PR TITLE
Fix mismatch between sort and used fields in Keypair.keyset

### DIFF
--- a/lib/keypair.rb
+++ b/lib/keypair.rb
@@ -86,7 +86,7 @@ class Keypair < ActiveRecord::Base
   #
   # @see https://www.imsglobal.org/spec/security/v1p0/#h_key-set-url
   def self.keyset
-    valid_keys = valid.order(expires_at: :asc).to_a
+    valid_keys = valid.order(not_before: :asc).to_a
     # If we don't have any keys or if we don't have a future key (i.e. the last key is the current key)
     while valid_keys.last.nil? || valid_keys.last.not_before <= Time.zone.now
       # There is an automatic fallback to Time.zone.now if not_before is not set

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -251,6 +251,19 @@ RSpec.describe Keypair, type: :model do
           expect(subject[:keys]).to eq(expected)
         end
       end
+
+      context 'with manual validity period on current keypair' do
+        let!(:keypair1) { described_class.create(not_after: 10.years.from_now, expires_at: 20.years.from_now) }
+
+        it 'creates a new future keypair' do
+          expect { described_class.keyset }.to change { described_class.count }.by(1)
+        end
+
+        it 'does not create a new future keypair on subsequent calls' do
+          described_class.keyset
+          expect { described_class.keyset }.to_not change { described_class.count }
+        end
+      end
     end
 
     describe '.cached_keyset' do


### PR DESCRIPTION
The valid keys of a keypair were sorted on `expires_at`, but for determining the validity of the keys it uses `not_before`. Therefore, when the `expires_at` of a keypair did not exactly match the default rotation period, there could be a mismatch between the actual future key, and the key that was used for checking whether there was a future key.

This fixes the use case of creating one keypair for development which does not rotate by manually setting the `not_after` and `expires_at` (as in the spec).