### PR TITLE
Add Ruby version matrix to CI for running specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - '3.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   rspec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - '3.0'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -30,6 +38,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - name: Install gems

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails # Rails-specific analysis
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Exclude:
     - 'tmp/**/*'

--- a/keypairs.gemspec
+++ b/keypairs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   MESSAGE
   spec.description = spec.summary
   spec.license     = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/Drieam/keypairs'


### PR DESCRIPTION
Closes #6

This also drops support for Ruby 2.5, which would be a breaking change. However, we can't run tests against 2.5, so I don't think we really supported it anyway.