### PR TITLE
fix: Use locking when creating new keypairs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       activerecord (>= 6.0)
       jwt (~> 2.1)
       lockbox (~> 0.4)
+      with_advisory_lock (~> 4.6)
 
 GEM
   remote: https://rubygems.org/
@@ -134,6 +135,8 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    with_advisory_lock (4.6.0)
+      activerecord (>= 4.2)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -155,4 +158,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.2.32
+   2.3.8

--- a/keypairs.gemspec
+++ b/keypairs.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord', '>= 6.0'                     # Depend on activerecord as ORM
   spec.add_dependency 'jwt', '~> 2.1'                              # Working with JSON Web Tokens
   spec.add_dependency 'lockbox', '~> 0.4'                          # Encrypt and decrypt attributes
+  spec.add_dependency 'with_advisory_lock', '~> 4.6'               # Advisory database-level locks
 
   spec.add_development_dependency 'appraisal'                      # Test against multiple gem versions
   spec.add_development_dependency 'brakeman'                       # Static analysis security vulnerability scanner

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -138,6 +138,17 @@ RSpec.describe Keypair, type: :model do
         it 'returns an instance' do
           expect(described_class.current).to be_a described_class
         end
+
+        it 'only creates 1 keypair with multiple threads' do
+          expect do
+            threads = Array.new(3).map do |_i|
+              Thread.new do
+                expect(described_class.current).to be_a Keypair
+              end
+            end
+            threads.each(&:join)
+          end.to change(described_class, :count).by(1)
+        end
       end
 
       context 'with valid keypairs' do
@@ -192,6 +203,17 @@ RSpec.describe Keypair, type: :model do
 
         it 'contains the public_jwk_export of only the valid keypairs' do
           expect(subject[:keys]).to eq(expected)
+        end
+
+        it 'only creates 1 keypair with multiple threads' do
+          expect do
+            threads = Array.new(3).map do |_i|
+              Thread.new do
+                expect(described_class.keyset[:keys].length).to eq 3
+              end
+            end
+            threads.each(&:join)
+          end.to change(described_class, :count).by(1)
         end
       end
 

--- a/spec/support/with_advisory_lock.rb
+++ b/spec/support/with_advisory_lock.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    ENV['FLOCK_DIR'] = Dir.mktmpdir
+  end
+
+  config.after(:suite) do
+    FileUtils.remove_entry_secure ENV['FLOCK_DIR']
+  end
+end


### PR DESCRIPTION
This adds an advisory lock when creating a new keypair to prevent
creating multiple keypairs for the same validity period.

Closes #10