### PR TITLE
chore: Remove reviewdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push]
 jobs:
-  reviewdog:
+  rubocop:
     runs-on: ubuntu-latest
 
     steps:
@@ -13,13 +13,23 @@ jobs:
           ruby-version: 3.3
           bundler-cache: true
 
-      - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
+      - name: Run rubocop
+        run: bundle exec rubocop
 
-      - name: Run reviewdog
-        run: reviewdog -reporter=github-check
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  brakeman:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Run brakeman
+        run: bundle exec brakeman --quiet --format tabs --force-scan
 
   rspec:
     strategy:

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,6 +1,0 @@
-runner:
-  rubocop:
-    cmd: bundle exec rubocop
-
-  brakeman:
-    cmd: bundle exec brakeman --quiet --format tabs --force-scan


### PR DESCRIPTION
Reviewdog has been compromised and may have leaked repository secrets. It is safer to get rid of reviewdog entirely.

See: https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup